### PR TITLE
Add factory to dispatch jobs

### DIFF
--- a/backend/app/controllers/v1/easycob/campaigns_controller.ts
+++ b/backend/app/controllers/v1/easycob/campaigns_controller.ts
@@ -10,7 +10,7 @@ import LoadCsvCampaignJob from '#jobs/load_csv_campaign_job'
 import { sep, normalize } from 'node:path'
 import fs from 'fs'
 import { serializeKeysCamelCase } from '#utils/serialize'
-import { JobFactory } from '#services/factories/job_factory'
+import { jobFactory } from '#services/factories/job_factory'
 import { InvalidArgumentsException } from '@adonisjs/core/exceptions'
 
 @inject()
@@ -89,7 +89,6 @@ export default class CampaignsController {
         //Criar class para enviar as campanhas
 
         if (lots.length > 0) {
-          const jobFactory = new JobFactory()
           if (campaign.type !== 'SMS' && campaign.type !== 'EMAIL') {
             throw new InvalidArgumentsException('Invalid campaign type')
           }

--- a/backend/app/controllers/v1/easycob/campaigns_controller.ts
+++ b/backend/app/controllers/v1/easycob/campaigns_controller.ts
@@ -1,64 +1,57 @@
-import type { HttpContext } from '@adonisjs/core/http';
-import db from '@adonisjs/lucid/services/db';
-import CampaignService from '#services/campaign_service';
-import { inject } from '@adonisjs/core';
-import app from '@adonisjs/core/services/app';
-import Campaign from '#models/campaign';
-import User from '#models/user';
-import CampaignLot from '#models/campaign_lot';
-import LoadCsvCampaignJob from '#jobs/load_csv_campaign_job';
-import { sep, normalize } from 'node:path';
-import fs from 'fs';
-import SendEmailJob from '#jobs/send_email_job';
-import SendSmsJob from '#jobs/send_sms_job';
-import { serializeKeysCamelCase } from '#utils/serialize';
+import type { HttpContext } from '@adonisjs/core/http'
+import db from '@adonisjs/lucid/services/db'
+import CampaignService from '#services/campaign_service'
+import { inject } from '@adonisjs/core'
+import app from '@adonisjs/core/services/app'
+import Campaign from '#models/campaign'
+import User from '#models/user'
+import CampaignLot from '#models/campaign_lot'
+import LoadCsvCampaignJob from '#jobs/load_csv_campaign_job'
+import { sep, normalize } from 'node:path'
+import fs from 'fs'
+import { serializeKeysCamelCase } from '#utils/serialize'
+import { JobFactory } from '#services/factories/JobFactory'
+import { InvalidArgumentsException } from '@adonisjs/core/exceptions'
 
 @inject()
 export default class CampaignsController {
-
-  constructor(protected service: CampaignService) {
-  }
+  constructor(protected service: CampaignService) {}
   public async index({ request }: HttpContext) {
-    const sql = fs.readFileSync('app/sql/campaign/exists_pendencies.sql', 'utf8');
-    const qs = request.qs();
-    const pageNumber = qs.page || '1';
-    const limit = qs.perPage || '10';
-    const orderBy = qs.orderBy || 'id';
-    const descending = qs.descending || 'true';
+    const sql = fs.readFileSync('app/sql/campaign/exists_pendencies.sql', 'utf8')
+    const qs = request.qs()
+    const pageNumber = qs.page || '1'
+    const limit = qs.perPage || '10'
+    const orderBy = qs.orderBy || 'id'
+    const descending = qs.descending || 'true'
 
-    const campaigns = await db.from('public.campaigns as c')
+    const campaigns = await db
+      .from('public.campaigns as c')
       .select('c.*')
-      .select(
-        db.raw(sql)
-      )
+      .select(db.raw(sql))
       .select('users.name as user')
       .innerJoin('users', 'users.id', '=', 'c.user_id')
       .where((q) => {
-        return this.service.generateWherePaginate(q, qs);
+        return this.service.generateWherePaginate(q, qs)
       })
       .orderBy(`c.${orderBy}`, descending === 'true' ? 'desc' : 'asc')
-      .paginate(pageNumber, limit);
+      .paginate(pageNumber, limit)
 
-    return serializeKeysCamelCase(campaigns.toJSON());
-
+    return serializeKeysCamelCase(campaigns.toJSON())
   }
 
   public async create({ auth, request, response }: HttpContext) {
+    const user: User = auth.user!
 
-    const user: User = auth.user!;
-
-    const payload = await this.service.createCampaignValidator(request);
-
+    const payload = await this.service.createCampaignValidator(request)
 
     try {
-      const newFileName = await this.service.handlerFile(request);
+      const newFileName = await this.service.handlerFile(request)
 
       const campaign = await Campaign.create({
         ...payload,
         fileName: `/csv/${newFileName}`,
         userId: user.id,
-      });
-
+      })
 
       await LoadCsvCampaignJob.dispatch(
         {
@@ -66,86 +59,67 @@ export default class CampaignsController {
           user_id: user.id,
         },
         {
-          queueName: 'LoadCsv'
-        },
-      );
+          queueName: 'LoadCsv',
+        }
+      )
 
       return {
         ...campaign.serialize(),
         url_file: `${campaign.fileName}`,
-      };
-
+      }
     } catch (error) {
       return response.badRequest({
-        errors: error
-      });
+        errors: error,
+      })
     }
-
   }
 
   public async send({ auth, params }: HttpContext) {
     try {
-      const user: User = auth.user!;
-      const { id } = params;
-      const campaign = await Campaign.find(id);
+      const user: User = auth.user!
+      const { id } = params
+      const campaign = await Campaign.find(id)
       if (campaign) {
         const lots = await CampaignLot.query()
           .where('campaign_id', campaign.id)
           .whereNotNull('contato')
           .whereNull('messageid')
-          .where('valid', true);
-
+          .where('valid', true)
 
         //Criar class para enviar as campanhas
 
         if (lots.length > 0) {
-
-          if (campaign.type === 'SMS') {
-            await SendSmsJob.dispatch(
-              {
-                campaign_id: id,
-                user_id: user.id,
-              },
-              {
-                queueName: 'SendSms'
-              },
-            );
+          const jobFactory = new JobFactory()
+          if (campaign.type !== 'SMS' && campaign.type !== 'EMAIL') {
+            throw new InvalidArgumentsException('Invalid campaign type')
           }
 
-          if (campaign.type === 'EMAIL') {
-            await SendEmailJob.dispatch(
-              {
-                campaign_id: id,
-                user_id: user.id,
-              },
-              {
-                queueName: 'SendEmail'
-              },
-            );
-          }
-          return true;
+          const job = jobFactory.getJob(campaign.type)
+          await job.dispatch({
+            campaign_id: id,
+            user_id: user.id,
+          })
 
+          return true
         }
-
       }
-      return false;
+      return false
     } catch (error) {
-      return error;
+      return error
     }
   }
 
   public getFile({ request, response }: HttpContext) {
+    const PATH_TRAVERSAL_REGEX = /(?:^|[\\/])\.\.(?:[\\/]|$)/
 
-    const PATH_TRAVERSAL_REGEX = /(?:^|[\\/])\.\.(?:[\\/]|$)/;
-
-    const filePath = request.param('*').join(sep);
-    const normalizedPath = normalize(filePath);
+    const filePath = request.param('*').join(sep)
+    const normalizedPath = normalize(filePath)
 
     if (PATH_TRAVERSAL_REGEX.test(normalizedPath)) {
-      return response.badRequest('Malformed path');
+      return response.badRequest('Malformed path')
     }
 
-    const absolutePath = app.makePath('uploads/csv', normalizedPath);
-    return response.download(absolutePath);
+    const absolutePath = app.makePath('uploads/csv', normalizedPath)
+    return response.download(absolutePath)
   }
 }

--- a/backend/app/controllers/v1/easycob/campaigns_controller.ts
+++ b/backend/app/controllers/v1/easycob/campaigns_controller.ts
@@ -10,7 +10,7 @@ import LoadCsvCampaignJob from '#jobs/load_csv_campaign_job'
 import { sep, normalize } from 'node:path'
 import fs from 'fs'
 import { serializeKeysCamelCase } from '#utils/serialize'
-import { JobFactory } from '#services/factories/JobFactory'
+import { JobFactory } from '#services/factories/job_factory'
 import { InvalidArgumentsException } from '@adonisjs/core/exceptions'
 
 @inject()
@@ -94,11 +94,16 @@ export default class CampaignsController {
             throw new InvalidArgumentsException('Invalid campaign type')
           }
 
-          const job = jobFactory.getJob(campaign.type)
-          await job.dispatch({
-            campaign_id: id,
-            user_id: user.id,
-          })
+          const { className: job, queueName } = jobFactory.getJob(campaign.type)
+          job.dispatch(
+            {
+              campaign_id: id,
+              user_id: user.id,
+            },
+            {
+              queueName,
+            }
+          )
 
           return true
         }

--- a/backend/app/services/factories/JobFactory.ts
+++ b/backend/app/services/factories/JobFactory.ts
@@ -1,0 +1,26 @@
+import SendEmailJob from '#jobs/send_email_job'
+import SendSmsJob from '#jobs/send_sms_job'
+
+export class JobFactory {
+  private kindToJobMap = {
+    SMS: {
+      className: SendSmsJob,
+      queueName: 'SendSms' as const,
+    },
+    EMAIL: {
+      className: SendEmailJob,
+      queueName: 'SendEmail' as const,
+    },
+  }
+
+  getJob<K extends keyof typeof this.kindToJobMap>(kind: K) {
+    const { className: jobClass, queueName } = this.kindToJobMap[kind]
+    return {
+      dispatch: (dispatchOptions: { campaign_id: number; user_id: number }) => {
+        return jobClass.dispatch(dispatchOptions, {
+          queueName,
+        })
+      },
+    }
+  }
+}

--- a/backend/app/services/factories/job_factory.ts
+++ b/backend/app/services/factories/job_factory.ts
@@ -14,13 +14,6 @@ export class JobFactory {
   }
 
   getJob<K extends keyof typeof this.kindToJobMap>(kind: K) {
-    const { className: jobClass, queueName } = this.kindToJobMap[kind]
-    return {
-      dispatch: (dispatchOptions: { campaign_id: number; user_id: number }) => {
-        return jobClass.dispatch(dispatchOptions, {
-          queueName,
-        })
-      },
-    }
+    return this.kindToJobMap[kind]
   }
 }

--- a/backend/app/services/factories/job_factory.ts
+++ b/backend/app/services/factories/job_factory.ts
@@ -1,19 +1,34 @@
-import SendEmailJob from '#jobs/send_email_job'
 import SendSmsJob from '#jobs/send_sms_job'
+import SendEmailJob from '#jobs/send_email_job'
 
-export class JobFactory {
-  private kindToJobMap = {
-    SMS: {
-      className: SendSmsJob,
-      queueName: 'SendSms' as const,
-    },
-    EMAIL: {
-      className: SendEmailJob,
-      queueName: 'SendEmail' as const,
-    },
+import { Job } from 'adonisjs-jobs'
+
+type Registry = Record<
+  string,
+  {
+    className: new () => Job
+    queueName: string
+  }
+>
+
+class JobFactory<R extends Registry> {
+  private registry: R
+  constructor(registry: R) {
+    this.registry = registry
   }
 
-  getJob<K extends keyof typeof this.kindToJobMap>(kind: K) {
-    return this.kindToJobMap[kind]
+  getJob<K extends keyof typeof this.registry>(key: K) {
+    return this.registry[key]
   }
 }
+
+export const jobFactory = new JobFactory({
+  SMS: {
+    className: SendSmsJob,
+    queueName: 'SendSms',
+  },
+  EMAIL: {
+    className: SendEmailJob,
+    queueName: 'SendEmail',
+  },
+} as const)


### PR DESCRIPTION
Este PR adiciona uma Factory para Jobs do BullMQ. Com essa implementação, as classes que despacham Jobs para a fila de envios não são mais responsáveis por construir o objeto com os parâmetros corretos. Essa função é delegada para a JobFactory que constrói o objeto correto de acordo com o tipo de Job passado no método getJob.  